### PR TITLE
Update schema database name to taskdb

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
-CREATE DATABASE IF NOT EXISTS collab_tool;
-USE collab_tool;
+CREATE DATABASE IF NOT EXISTS taskdb;
+USE taskdb;
 
 -- 사용자 테이블
 CREATE TABLE IF NOT EXISTS users (


### PR DESCRIPTION
## Summary
- update the schema to create and use the `taskdb` database
- ensure no remaining references to the old `collab_tool` name remain in the schema

## Testing
- not run (mysql client not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db76abb9cc8323b4f44677d026c4bc