### PR TITLE
Add task management drawer UI and route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,8 @@ import StatusBoard from "./calendar/StatusBoard";
 
 // 🔐 관리자
 import AdminPage from "./admin/AdminPage";
+// ✅ 업무 관리
+import TaskManager from "./tasks/TaskManager";
 
 function App() {
   const [logged, setLogged] = useState(!!localStorage.getItem("token"));
@@ -96,6 +98,16 @@ function App() {
           element={
             <ProtectedRoute>
               <StatusBoard token={localStorage.getItem("token")} />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* 업무 관리 */}
+        <Route
+          path="/tasks"
+          element={
+            <ProtectedRoute>
+              <TaskManager />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/tasks/TaskDetail.js
+++ b/frontend/src/tasks/TaskDetail.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+export default function TaskDetail({ task }) {
+  return (
+    <div className="task-detail">
+      <h2 className="section-title">업무 상세</h2>
+      <article>
+        <h3>{task.title}</h3>
+        <p className="description">{task.description}</p>
+
+        <div className="detail-section">
+          <h4>담당자</h4>
+          <ul>
+            {task.assignees?.map((name) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="detail-section">
+          <h4>하위 업무</h4>
+          {task.subtasks?.length ? (
+            <ul>
+              {task.subtasks.map((subtask) => (
+                <li key={subtask.id}>
+                  <div className="subtask-header">
+                    <strong>{subtask.title}</strong>
+                    <span>
+                      {subtask.startDate} ~ {subtask.endDate}
+                    </span>
+                  </div>
+                  {subtask.details?.length ? (
+                    <ul className="detail-list">
+                      {subtask.details.map((detail) => (
+                        <li key={detail.id}>
+                          <span>{detail.title}</span>
+                          <span>
+                            {detail.startDate} ~ {detail.endDate}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="empty">세부 업무가 없습니다.</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="empty">등록된 하위 업무가 없습니다.</p>
+          )}
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/tasks/TaskDrawer.css
+++ b/frontend/src/tasks/TaskDrawer.css
@@ -1,0 +1,230 @@
+/* Overlay (오버레이) */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 999;
+}
+
+/* Drawer 본체 */
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 480px;
+  height: 100%;
+  background: #fff;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.15);
+  transform: translateX(100%);
+  transition: transform 0.28s ease;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer__header {
+  padding: 16px 18px;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.drawer__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.drawer__header .close {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.drawer__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.drawer__footer {
+  padding: 12px 18px;
+  border-top: 1px solid #eee;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  background: #fafafa;
+}
+
+.btn {
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+}
+
+.btn.primary {
+  background: #2f9e44;
+  color: #fff;
+}
+
+.btn.secondary {
+  background: #eee;
+  color: #333;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.textarea {
+  min-height: 80px;
+  resize: none;
+}
+
+.subtask-box {
+  padding: 12px;
+  border: 1px solid #eee;
+  border-radius: 6px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detail-box {
+  padding-left: 10px;
+  border-left: 3px solid #ddd;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.assignee-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid #eee;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.assignee-item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.date-range {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.page-title {
+  font-size: 28px;
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
+.task-manager {
+  padding: 24px;
+}
+
+.task-list,
+.task-detail {
+  margin-top: 24px;
+}
+
+.task-list ul,
+.task-detail ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.task-list li + li,
+.task-detail li + li {
+  margin-top: 12px;
+}
+
+.task-list button {
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 12px;
+  cursor: pointer;
+}
+
+.task-list button:hover {
+  border-color: #2f9e44;
+}
+
+.section-title {
+  font-size: 20px;
+  margin-bottom: 12px;
+}
+
+.task-detail article {
+  border: 1px solid #eee;
+  padding: 16px;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.task-detail .description {
+  margin: 0 0 16px 0;
+}
+
+.detail-section + .detail-section {
+  margin-top: 16px;
+}
+
+.subtask-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.detail-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  border-left: 2px solid #f0f0f0;
+}
+
+.detail-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 12px;
+  margin-bottom: 6px;
+  background: #fafafa;
+  border-radius: 4px;
+}
+
+.empty {
+  color: #888;
+  font-size: 14px;
+}

--- a/frontend/src/tasks/TaskForm.css
+++ b/frontend/src/tasks/TaskForm.css
@@ -1,0 +1,23 @@
+.task-form label {
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+}
+
+.task-form .assignee-list label {
+  font-weight: 400;
+}
+
+.task-form .btn.secondary {
+  align-self: flex-start;
+}
+
+.task-form .drawer__footer {
+  margin-top: 12px;
+}
+
+.task-form input[type="date"] {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}

--- a/frontend/src/tasks/TaskList.js
+++ b/frontend/src/tasks/TaskList.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+
+const MOCK_TASKS = [
+  {
+    id: 1,
+    title: "프로젝트 킥오프 준비",
+    description: "프로젝트 일정과 범위를 정리합니다.",
+    assignees: ["홍길동", "김철수"],
+    subtasks: [
+      {
+        id: 11,
+        title: "Kick-off 자료 작성",
+        startDate: "2024-09-01",
+        endDate: "2024-09-02",
+        details: [
+          {
+            id: 111,
+            title: "요약본 정리",
+            startDate: "2024-09-01",
+            endDate: "2024-09-01",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 2,
+    title: "디자인 시안 검토",
+    description: "1차 시안을 검토하고 피드백을 정리합니다.",
+    assignees: ["이영희"],
+    subtasks: [],
+  },
+];
+
+export default function TaskList({ onSelectTask }) {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    setTasks(MOCK_TASKS);
+  }, []);
+
+  return (
+    <div className="task-list">
+      <h2 className="section-title">업무 목록</h2>
+      <ul>
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <button type="button" onClick={() => onSelectTask(task)}>
+              <strong>{task.title}</strong>
+              <p>{task.description}</p>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/tasks/TaskManager.js
+++ b/frontend/src/tasks/TaskManager.js
@@ -1,0 +1,247 @@
+import React, { useState, useEffect } from "react";
+import TaskList from "./TaskList";
+import TaskDetail from "./TaskDetail";
+import "./TaskDrawer.css";
+import "./TaskForm.css";
+
+export default function TaskManager() {
+  const [selectedTask, setSelectedTask] = useState(null);
+  const [open, setOpen] = useState(false);
+
+  function TaskRegistration({ onClose }) {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [assignees, setAssignees] = useState([]);
+    const [employees, setEmployees] = useState([]);
+    const [subtasks, setSubtasks] = useState([
+      {
+        title: "",
+        startDate: "",
+        endDate: "",
+        details: [{ title: "", startDate: "", endDate: "" }],
+      },
+    ]);
+
+    useEffect(() => {
+      setEmployees([
+        { emp_id: 1, name: "홍길동" },
+        { emp_id: 2, name: "김철수" },
+        { emp_id: 3, name: "이영희" },
+      ]);
+    }, []);
+
+    const toggleAssignee = (id) => {
+      setAssignees((prev) =>
+        prev.includes(id) ? prev.filter((emp) => emp !== id) : [...prev, id]
+      );
+    };
+
+    const handleSubtaskChange = (index, field, value) => {
+      setSubtasks((prev) => {
+        const next = [...prev];
+        next[index][field] = value;
+        return next;
+      });
+    };
+
+    const handleDetailChange = (subIndex, detailIndex, field, value) => {
+      setSubtasks((prev) => {
+        const next = [...prev];
+        next[subIndex].details[detailIndex][field] = value;
+        return next;
+      });
+    };
+
+    const handleAddSubtask = () => {
+      setSubtasks((prev) => [
+        ...prev,
+        {
+          title: "",
+          startDate: "",
+          endDate: "",
+          details: [{ title: "", startDate: "", endDate: "" }],
+        },
+      ]);
+    };
+
+    const handleAddSubDetail = (subIndex) => {
+      setSubtasks((prev) => {
+        const next = [...prev];
+        next[subIndex].details.push({
+          title: "",
+          startDate: "",
+          endDate: "",
+        });
+        return next;
+      });
+    };
+
+    const handleSubmit = () => {
+      console.log("상위 업무:", title);
+      console.log("내용:", description);
+      console.log("담당자:", assignees);
+      console.log("하위업무:", subtasks);
+      alert("프론트 테스트 완료!");
+      onClose();
+    };
+
+    return (
+      <div className="drawer__body task-form">
+        <h2>📌 업무 등록</h2>
+
+        <label>업무 제목</label>
+        <input
+          placeholder="업무 제목 입력"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="input"
+        />
+
+        <label>업무 내용</label>
+        <textarea
+          placeholder="업무 내용 입력"
+          value={description}
+          onChange={(e) => {
+            setDescription(e.target.value);
+            e.target.style.height = "auto";
+            e.target.style.height = `${e.target.scrollHeight}px`;
+          }}
+          className="textarea"
+        />
+
+        <label>담당자 지정</label>
+        <div className="assignee-list">
+          {employees.map((emp) => (
+            <label key={emp.emp_id} className="assignee-item">
+              <input
+                type="checkbox"
+                checked={assignees.includes(emp.emp_id)}
+                onChange={() => toggleAssignee(emp.emp_id)}
+              />
+              {emp.name}
+            </label>
+          ))}
+        </div>
+
+        {subtasks.map((sub, subIndex) => (
+          <div key={subIndex} className="subtask-box">
+            <input
+              placeholder="하위 업무 제목"
+              value={sub.title}
+              onChange={(e) =>
+                handleSubtaskChange(subIndex, "title", e.target.value)
+              }
+              className="input"
+            />
+            <div className="date-range">
+              <input
+                type="date"
+                value={sub.startDate}
+                onChange={(e) =>
+                  handleSubtaskChange(subIndex, "startDate", e.target.value)
+                }
+              />
+              <span>~</span>
+              <input
+                type="date"
+                value={sub.endDate}
+                onChange={(e) =>
+                  handleSubtaskChange(subIndex, "endDate", e.target.value)
+                }
+              />
+            </div>
+
+            {sub.details.map((d, detailIndex) => (
+              <div key={detailIndex} className="detail-box">
+                <input
+                  placeholder="세부 업무 제목"
+                  value={d.title}
+                  onChange={(e) =>
+                    handleDetailChange(
+                      subIndex,
+                      detailIndex,
+                      "title",
+                      e.target.value
+                    )
+                  }
+                  className="input"
+                />
+                <div className="date-range">
+                  <input
+                    type="date"
+                    value={d.startDate}
+                    onChange={(e) =>
+                      handleDetailChange(
+                        subIndex,
+                        detailIndex,
+                        "startDate",
+                        e.target.value
+                      )
+                    }
+                  />
+                  <span>~</span>
+                  <input
+                    type="date"
+                    value={d.endDate}
+                    onChange={(e) =>
+                      handleDetailChange(
+                        subIndex,
+                        detailIndex,
+                        "endDate",
+                        e.target.value
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            ))}
+            <button
+              onClick={() => handleAddSubDetail(subIndex)}
+              className="btn secondary"
+              type="button"
+            >
+              ➕ 세부 업무 추가
+            </button>
+          </div>
+        ))}
+
+        <button onClick={handleAddSubtask} className="btn secondary" type="button">
+          ➕ 하위 업무 추가
+        </button>
+
+        <div className="drawer__footer">
+          <button onClick={handleSubmit} className="btn primary" type="button">
+            저장
+          </button>
+          <button onClick={onClose} className="btn secondary" type="button">
+            취소
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="task-manager">
+      <h1 className="page-title">프로젝트 대시보드</h1>
+
+      <button className="btn primary" onClick={() => setOpen(true)} type="button">
+        업무 등록
+      </button>
+
+      <TaskList onSelectTask={setSelectedTask} />
+      {selectedTask && <TaskDetail task={selectedTask} />}
+
+      {open && <div className="overlay" onClick={() => setOpen(false)} />}
+      <aside className={`drawer ${open ? "open" : ""}`}>
+        <div className="drawer__header">
+          <h2>업무 등록</h2>
+          <button className="close" onClick={() => setOpen(false)} type="button">
+            ✕
+          </button>
+        </div>
+        <TaskRegistration onClose={() => setOpen(false)} />
+      </aside>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a task management dashboard component with a drawer-based registration form and example task list/detail views
- wire the new task manager into the router and include scoped styles for the drawer and form layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd6a1ddb483238a7f6c1e9ee80060